### PR TITLE
Fix docs

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -5,11 +5,8 @@ version: 2
 build:
   image: latest
 
-python:
-  version: 3.8
-  install:
-    - method: pip
-      path: .
+sphinx:
+  configuration: docs/conf.py
 
 conda:
-  environment: docs/requirements.yaml
+  environment: devtools/conda-envs/test_env.yaml


### PR DESCRIPTION
## Description
Fix docs.

## Notes
The following files have to be adapted when using notebooks with readthedocs:
- `./readthedocs.yml`
- `docs/requirements.yaml`
- `devtools/conda-envs/test_env.yaml`

## Status
- [x] Ready to go